### PR TITLE
채팅 리스트 1차

### DIFF
--- a/server/controller/chatListController.js
+++ b/server/controller/chatListController.js
@@ -1,27 +1,105 @@
 import Chat from '../schema/ChatSchema.js'
+import User from '../schema/UserSchema.js'
+import * as authRepository from '../query/authQuery.js'
 import mongoose from 'mongoose';
 
 export async function getChatRoomList(req, res) {
-    const userId = req.user.id; // 사용자 인증 미들웨어로 가져온 사용자 ID
+    // const userId = req.user.id; // 사용자 인증 미들웨어로 가져온 사용자 ID
+    const mongo_id = req.mongo_id; // 로그인한 사용자 ID
+    console.log('로그인한 사용자 ID:', mongo_id);
 
     try {
-        const taskUserRooms = await Chat.find({ TaskUserId: userId })
-        .sort({ lastMessageTime: -1 })
-        .populate('participants', 'nickname profileImage')
-        .select('channel lastMessage lastMessageTime participants');
+        // const taskUserRooms = await Chat.find({ TaskUserId: new mongoose.Types.ObjectId(mongo_id) })
+        // .sort({ lastMessageTime: -1 })
+        // .select('_id lastMessage lastMessageTime TaskUserId toTaskUserId');
     
-        // toTaskUserId로 검색
-        const toTaskUserRooms = await Chat.find({ toTaskUserId: userId })
-            .sort({ lastMessageTime: -1 })
-            .populate('participants', 'nickname profileImage')
-            .select('channel lastMessage lastMessageTime participants');
+        // // toTaskUserId로 검색
+        // const toTaskUserRooms = await Chat.find({ toTaskUserId: new mongoose.Types.ObjectId(mongo_id) })
+        //     .sort({ lastMessageTime: -1 })
+        //     .select('_id lastMessage lastMessageTime TaskUserId toTaskUserId');
         
-        // 두 검색 결과를 합치기
-        const chatRooms = [...taskUserRooms, ...toTaskUserRooms];
+        // // 두 검색 결과를 합치기
+        // const chatRooms = [...taskUserRooms, ...toTaskUserRooms];
         
-        console.log('검색된 채팅방 리스트:', chatRooms,taskUserRooms,toTaskUserRooms);
+        // console.log('검색된 채팅방 리스트:', chatRooms,taskUserRooms,toTaskUserRooms);
 
-        res.status(200).json({ success: true, data: chatRooms });
+
+        // // 닉네임 정보 추가
+        // const otherUserNickname = await Promise.all(
+        //     chatRooms.map(async (room) => {
+        //         const otherUserId =
+        //             room.TaskUserId.toString() === mongo_id
+        //                 ? room.toTaskUserId
+        //                 : room.TaskUserId;
+
+        //         // 다른 사용자의 닉네임 가져오기
+        //         const otherUser = await User.findById(otherUserId).select('nickname');
+
+        //         return {
+        //             _id: room._id,
+        //             lastMessage: room.lastMessage,
+        //             lastMessageTime: room.lastMessageTime,
+        //             otherUserNickname: otherUser?.nickname || 'Unknown User',
+        //         };
+        //     })
+        // );
+        // console.log('채팅방 리스트:', otherUserNickname);
+        // 이제 닉네임도 같이 보내면됨
+        //  다만 TaskUserId로 찾았다면 toTaskUserId로 User.find로 닉네임을 찾아서 보내야하고
+        // toTaskUserId로 찾았다면 TaskUserId로 User.find로 닉네임을 찾아서 보내면 됨
+
+        // TaskUserId로 검색
+        const taskUserRooms = await Chat.find({ TaskUserId: new mongoose.Types.ObjectId(mongo_id) })
+            .sort({ lastMessageTime: -1 })
+            .select('_id lastMessage lastMessageTime TaskUserId toTaskUserId');
+
+        // toTaskUserId로 검색
+        const toTaskUserRooms = await Chat.find({ toTaskUserId: new mongoose.Types.ObjectId(mongo_id) })
+            .sort({ lastMessageTime: -1 })
+            .select('_id lastMessage lastMessageTime TaskUserId toTaskUserId');
+
+        // 두 검색 결과 합치기
+        const chatRooms = [...taskUserRooms, ...toTaskUserRooms];
+
+        // 닉네임 정보 추가
+        const chatRoomsWithNicknames = await Promise.all(
+            chatRooms.map(async (room) => {
+                let otherUserId;
+                let otherUserNickname;
+
+                // TaskUserId로 데이터를 찾았을 경우
+                if (room.TaskUserId.toString() === mongo_id) {
+                    otherUserId = room.toTaskUserId; // 상대방 ID는 toTaskUserId
+                }
+                // toTaskUserId로 데이터를 찾았을 경우
+                else if (room.toTaskUserId.toString() === mongo_id) {
+                    otherUserId = room.TaskUserId; // 상대방 ID는 TaskUserId
+                }
+                console.log('otherUserId',otherUserId);
+
+                // 상대방 ID로 닉네임 조회
+                if (otherUserId) {
+                    const otherUser = await User.findById(new mongoose.Types.ObjectId(otherUserId))
+                        .select('nickname');
+                    otherUserNickname = otherUser?.nickname || 'Unknown User';
+                } else {
+                    otherUserNickname = 'Unknown User';
+                }
+
+                return {
+                    _id: room._id,
+                    lastMessage: room.lastMessage,
+                    lastMessageTime: room.lastMessageTime,
+                    otherUserNickname: otherUserNickname
+                };
+            })
+        );
+
+        console.log('채팅방 리스트:', chatRoomsWithNicknames);
+
+        res.status(200).json({ success: true, data: chatRoomsWithNicknames });
+
+        // res.status(200).json({ success: true, data: chatRooms });
     } catch (error) {
         console.error('채팅룸 리스트 조회 중 오류:', error);
         res.status(500).json({ success: false, message: '채팅룸 리스트 조회 실패', error });


### PR DESCRIPTION
내정보 페이지 계속 데이터 불러오는거 고치고 ,post에 신청하기 한번 누르면 그 다음부터는 신청하기 버튼 안뜨게하고,채팅 리스트에서 상대방 유저 닉네임 불러오는거 고치고, 채팅방에서 sender로 상대방과 나 구분해서 메세지 보여주게하기